### PR TITLE
Caldoor: Authorize Void transaction functionality.

### DIFF
--- a/caldoor_authorize/models/payment.py
+++ b/caldoor_authorize/models/payment.py
@@ -58,12 +58,20 @@ class PaymentTransaction(models.Model):
     def _authorize_s2s_validate(self, tree):
         result = super(PaymentTransaction, self)._authorize_s2s_validate(tree)
         status_code = int(tree.get('x_response_code', '0'))
-        if status_code == self._authorize_valid_tx_status and tree.get('x_type').lower() == 'refund':
-            self.write({
-                'acquirer_reference': tree.get('x_trans_id'),
-                'date': fields.Datetime.now(),
-            })
-            self._set_transaction_done()
+        if status_code == self._authorize_valid_tx_status:
+            if tree.get('x_type').lower() == 'refund':
+                self.write({
+                    'acquirer_reference': tree.get('x_trans_id'),
+                    'date': fields.Datetime.now(),
+                })
+                self._set_transaction_done()
+            elif tree.get('x_type').lower() == 'void' and self.state == 'done':
+                self.write({
+                    'state': 'cancel',
+                    'date': fields.Date.today()
+                })
+                self._log_payment_transaction_received()
+
             result = True
         return result
 
@@ -157,12 +165,12 @@ class AccountPayment(models.Model):
 
     @api.multi
     def cancel(self):
-        electronic_payments = self.filtered(lambda p: (p.payment_method_code == 'electric') and p.payment_transaction_id)
+        electronic_payments = self.filtered(lambda p: (p.payment_method_code == 'electronic') and p.payment_transaction_id)
         if any([p.payment_date < fields.Date.today() for p in electronic_payments]):
             raise ValidationError(_("You can not cancel electronic payment 24 hour after validation."))
         res = super(AccountPayment, self).cancel()
         for payment in electronic_payments:
-            payment.payment_transaction_id.action_void()
+            payment.payment_transaction_id.s2s_void_transaction()
         return res
 
     @api.multi

--- a/caldoor_authorize/models/payment.py
+++ b/caldoor_authorize/models/payment.py
@@ -166,7 +166,7 @@ class AccountPayment(models.Model):
     @api.multi
     def cancel(self):
         electronic_payments = self.filtered(lambda p: (p.payment_method_code == 'electronic') and p.payment_transaction_id)
-        if any([p.payment_date < fields.Date.today() for p in electronic_payments]):
+        if any([p.payment_date < fields.Date.context_today(p) for p in electronic_payments]):
             raise ValidationError(_("You can not cancel electronic payment 24 hour after validation."))
         res = super(AccountPayment, self).cancel()
         for payment in electronic_payments:

--- a/caldoor_authorize/views/payment_views.xml
+++ b/caldoor_authorize/views/payment_views.xml
@@ -35,6 +35,9 @@
                 <field name="authorize_refund_transaction_id" attrs="{'invisible': ['|', ('payment_method_code', '!=', 'authorize_ct'), '|', ('partner_id', '=', False), ('payment_type', '=', 'transfer')], 'required': [('payment_method_code', '=', 'authorize_ct')], 'readonly': [('state', '!=', 'draft')]}" options="{'no_create': True}"/>
                 <field name="authorize_payment_token_id" attrs="{'invisible': ['|', ('authorize_refund_transaction_id', '=', False), '|', ('payment_method_code', '!=', 'authorize_ct'), '|', ('partner_id', '=', False), ('payment_type', '=', 'transfer')]}" options="{'no_create': True}"/>
             </xpath>
+            <button name="cancel" position="attributes">
+                <attribute name='confirm'>Are you sure you want to cancel this payment? This action can't be undone.</attribute>
+            </button>
         </field>
     </record>
 


### PR DESCRIPTION
- one can directly cancel the electronic payment and the transaction associated with it will also gets 
  voided from authorize and cancelled it the cancellation has been done within 24 hours of the 
  payment.